### PR TITLE
[Enhancement] avoid CA1701 for automatically generated code files

### DIFF
--- a/Aras.VS.MethodPlugin/Code/CSharpCodeProvider.cs
+++ b/Aras.VS.MethodPlugin/Code/CSharpCodeProvider.cs
@@ -82,7 +82,7 @@ namespace Aras.VS.MethodPlugin.Code
 			const string fncname = "FNCMethod";
 			var eventDataClass = eventData.EventDataClass;
 			var interfaceName = eventData.InterfaceName;
-			string methodNameWithOutSpases = methodName.Replace(' ', '_');
+			string methodNameWithOutSpases = methodName.Replace(" ", string.Empty).Replace("_", string.Empty);
 			var clsname = "ArasCLS" + methodNameWithOutSpases;
 			var pkgname = "ArasPKG" + methodNameWithOutSpases;
 


### PR DESCRIPTION
Added replace of ' ' and "_" symbols to empty string for
'namespace' and 'method name' in automatic generated code