### PR TITLE
String is modified on save to AML package. Fixed encoding of the "]]>" in the middle of a CDATA section

### DIFF
--- a/Aras.VS.MethodPlugin/Commands/SaveToPackageCmd.cs
+++ b/Aras.VS.MethodPlugin/Commands/SaveToPackageCmd.cs
@@ -188,7 +188,7 @@ namespace Aras.VS.MethodPlugin.Commands
 				methodId = saveViewResult.MethodInformation.InnovatorMethodConfigId;
 			}
 
-			string updateMethodCodeForSavingToAmlPackage = saveViewResult.MethodCode.Replace("]]", "]]]]><![CDATA[");
+			string updateMethodCodeForSavingToAmlPackage = saveViewResult.MethodCode.Replace("]]>", "]]]]><![CDATA[>");
 			string methodTemplate = $@"<AML>
  <Item type=""Method"" id=""{methodId}"" action=""add"">" + 
   (!string.IsNullOrWhiteSpace(saveViewResult.MethodComment) ? $"<comments>{saveViewResult.MethodComment}</comments>" : "") +


### PR DESCRIPTION
 * Issue #11