### PR TITLE
[Critical] Partial elements are removed after save to AML/Innovator

### DIFF
--- a/Aras.VS.MethodPlugin.Tests/Code/TestData/LoadMethodCode/ExpectedSourceCode.txt
+++ b/Aras.VS.MethodPlugin.Tests/Code/TestData/LoadMethodCode/ExpectedSourceCode.txt
@@ -10,4 +10,3 @@
 
             return resultItem;
     	
-}

--- a/Aras.VS.MethodPlugin.Tests/Code/TestData/LoadMethodCode/SourceCode.txt
+++ b/Aras.VS.MethodPlugin.Tests/Code/TestData/LoadMethodCode/SourceCode.txt
@@ -32,7 +32,6 @@ namespace ArasPKGMSO_GetAllSettings
 
             return resultItem;
     	
-}
 #endregion MethodCode
 // end your code inside region MethodCode - DO NOT CHANGE CODE BELOW
         }


### PR DESCRIPTION
Added move of method code 'endregion' in case
when we have only a partial elements