### PR TITLE
76 Can't edit server method. Added try-catch in case when "Edit.Goto"…

### DIFF
--- a/Aras.VS.MethodPlugin/SolutionManagement/ProjectManager.cs
+++ b/Aras.VS.MethodPlugin/SolutionManagement/ProjectManager.cs
@@ -419,7 +419,15 @@ namespace Aras.VS.MethodPlugin.SolutionManagement
 				var window = folder.ProjectItems.Item(codefileName).Open(EnvDTE.Constants.vsViewKindCode);
 				window.Visible = true;
 				DTE dte = (DTE)this.vsPackageWrapper.GetGlobalService(typeof(DTE));
-				dte.ExecuteCommand("Edit.Goto", cursorIndex.ToString());
+
+				try
+				{
+					dte.ExecuteCommand("Edit.Goto", cursorIndex.ToString());
+				}
+				catch
+				{
+
+				}
 			}
 
 			return fileFullPath;


### PR DESCRIPTION
Added try-catch in case when "Edit.Goto" is broken in VS.

For some configuration of VS "Edit.Goto"
not works from code.